### PR TITLE
:truck: splitting multi-context config into separate files

### DIFF
--- a/config-delivery-prod-eu
+++ b/config-delivery-prod-eu
@@ -1,0 +1,20 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: credentials-prod-eu/ca.pem
+    server: https://upp-prod-delivery-eu-api.ft.com
+  name: upp-prod-delivery-eu
+contexts:
+- context:
+    cluster: upp-prod-delivery-eu
+    namespace: default
+    user: upp-prod-eu-admin
+  name: upp-prod-delivery-eu
+current-context: upp-prod-delivery-eu
+kind: Config
+preferences: {}
+users:
+- name: upp-prod-eu-admin
+  user:
+    client-certificate: credentials-prod-eu/admin.pem
+    client-key: credentials-prod-eu/admin-key.pem

--- a/config-delivery-prod-us
+++ b/config-delivery-prod-us
@@ -1,0 +1,20 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: credentials-prod-us/ca.pem
+    server: https://upp-prod-delivery-us-api.ft.com
+  name: upp-prod-delivery-us
+contexts:
+- context:
+    cluster: upp-prod-delivery-us
+    namespace: default
+    user: upp-prod-us-admin
+  name: upp-prod-delivery-us
+current-context: upp-prod-delivery-us
+kind: Config
+preferences: {}
+users:
+- name: upp-prod-us-admin
+  user:
+    client-certificate: credentials-prod-us/admin.pem
+    client-key: credentials-prod-us/admin-key.pem

--- a/config-neo4j-prod-eu
+++ b/config-neo4j-prod-eu
@@ -1,0 +1,20 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: credentials-prod-eu/ca.pem
+    server: https://upp-prod-neo4j-eu-api.ft.com
+  name: upp-prod-neo4j-eu
+contexts:
+- context:
+    cluster: upp-prod-neo4j-eu
+    namespace: default
+    user: upp-prod-eu-admin
+  name: upp-prod-neo4j-eu
+current-context: upp-prod-neo4j-eu
+kind: Config
+preferences: {}
+users:
+- name: upp-prod-eu-admin
+  user:
+    client-certificate: credentials-prod-eu/admin.pem
+    client-key: credentials-prod-eu/admin-key.pem

--- a/config-neo4j-prod-us
+++ b/config-neo4j-prod-us
@@ -1,0 +1,20 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: credentials-prod-us/ca.pem
+    server: https://upp-prod-neo4j-us-api.ft.com
+  name: upp-prod-neo4j-us
+contexts:
+- context:
+    cluster: upp-prod-neo4j-us
+    namespace: default
+    user: upp-prod-us-admin
+  name: upp-prod-neo4j-us
+current-context: upp-prod-neo4j-us
+kind: Config
+preferences: {}
+users:
+- name: upp-prod-us-admin
+  user:
+    client-certificate: credentials-prod-us/admin.pem
+    client-key: credentials-prod-us/admin-key.pem

--- a/config-publish-prod-eu
+++ b/config-publish-prod-eu
@@ -1,0 +1,20 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: credentials-prod-eu/ca.pem
+    server: https://upp-prod-publish-eu-api.ft.com
+  name: upp-prod-publish-eu
+contexts:
+- context:
+    cluster: upp-prod-publish-eu
+    namespace: default
+    user: upp-prod-eu-admin
+  name: upp-prod-publish-eu
+current-context: upp-prod-publish-eu
+kind: Config
+preferences: {}
+users:
+- name: upp-prod-eu-admin
+  user:
+    client-certificate: credentials-prod-eu/admin.pem
+    client-key: credentials-prod-eu/admin-key.pem

--- a/config-publish-prod-us
+++ b/config-publish-prod-us
@@ -1,0 +1,20 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority: credentials-prod-us/ca.pem
+    server: https://upp-prod-publish-us-api.ft.com
+  name: upp-prod-publish-us
+contexts:
+- context:
+    cluster: upp-prod-publish-us
+    namespace: default
+    user: upp-prod-us-admin
+  name: upp-prod-publish-us
+current-context: upp-prod-publish-us
+kind: Config
+preferences: {}
+users:
+- name: upp-prod-us-admin
+  user:
+    client-certificate: credentials-prod-us/admin.pem
+    client-key: credentials-prod-us/admin-key.pem


### PR DESCRIPTION
Multi-context config runs into problems when it's a single file shared by multiple users on a jumpbox - as anyone switching context will switch context for ALL users on that server.

For Ops, it makes more sense to split out the config into separate files, then add a wrapper script (in  the [CoCo jumpbox repo](http://git.svc.ft.com/projects/CP/repos/coco_jumpoff/browse)).

For everyone else, I've left both single- and multi-context config files here until I've decided what I want to do with this.